### PR TITLE
feat: delete ports and networks options

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -109,10 +109,9 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		},
 		&StepRunSourceServer{
 			Name:             b.config.InstanceName,
-			SecurityGroups:   b.config.SecurityGroups,
-			Networks:         b.config.Networks,
 			VpcID:            b.config.VpcID,
 			Subnets:          b.config.Subnets,
+			SecurityGroups:   b.config.SecurityGroups,
 			UserData:         b.config.UserData,
 			UserDataFile:     b.config.UserDataFile,
 			ConfigDrive:      b.config.ConfigDrive,

--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -111,7 +111,6 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Name:             b.config.InstanceName,
 			SecurityGroups:   b.config.SecurityGroups,
 			Networks:         b.config.Networks,
-			Ports:            b.config.Ports,
 			VpcID:            b.config.VpcID,
 			Subnets:          b.config.Subnets,
 			UserData:         b.config.UserData,

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -93,7 +93,6 @@ type FlatConfig struct {
 	EIPBandwidthSize          *int              `mapstructure:"eip_bandwidth_size" required:"false" cty:"eip_bandwidth_size" hcl:"eip_bandwidth_size"`
 	SecurityGroups            []string          `mapstructure:"security_groups" required:"false" cty:"security_groups" hcl:"security_groups"`
 	Networks                  []string          `mapstructure:"networks" required:"false" cty:"networks" hcl:"networks"`
-	Ports                     []string          `mapstructure:"ports" required:"false" cty:"ports" hcl:"ports"`
 	VpcID                     *string           `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
 	Subnets                   []string          `mapstructure:"subnets" required:"false" cty:"subnets" hcl:"subnets"`
 	UserData                  *string           `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -201,7 +200,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"eip_bandwidth_size":           &hcldec.AttrSpec{Name: "eip_bandwidth_size", Type: cty.Number, Required: false},
 		"security_groups":              &hcldec.AttrSpec{Name: "security_groups", Type: cty.List(cty.String), Required: false},
 		"networks":                     &hcldec.AttrSpec{Name: "networks", Type: cty.List(cty.String), Required: false},
-		"ports":                        &hcldec.AttrSpec{Name: "ports", Type: cty.List(cty.String), Required: false},
 		"vpc_id":                       &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},
 		"subnets":                      &hcldec.AttrSpec{Name: "subnets", Type: cty.List(cty.String), Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -91,10 +91,9 @@ type FlatConfig struct {
 	ReuseIPs                  *bool             `mapstructure:"reuse_ips" required:"false" cty:"reuse_ips" hcl:"reuse_ips"`
 	EIPType                   *string           `mapstructure:"eip_type" required:"false" cty:"eip_type" hcl:"eip_type"`
 	EIPBandwidthSize          *int              `mapstructure:"eip_bandwidth_size" required:"false" cty:"eip_bandwidth_size" hcl:"eip_bandwidth_size"`
-	SecurityGroups            []string          `mapstructure:"security_groups" required:"false" cty:"security_groups" hcl:"security_groups"`
-	Networks                  []string          `mapstructure:"networks" required:"false" cty:"networks" hcl:"networks"`
 	VpcID                     *string           `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
 	Subnets                   []string          `mapstructure:"subnets" required:"false" cty:"subnets" hcl:"subnets"`
+	SecurityGroups            []string          `mapstructure:"security_groups" required:"false" cty:"security_groups" hcl:"security_groups"`
 	UserData                  *string           `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile              *string           `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	InstanceName              *string           `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
@@ -198,10 +197,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"reuse_ips":                    &hcldec.AttrSpec{Name: "reuse_ips", Type: cty.Bool, Required: false},
 		"eip_type":                     &hcldec.AttrSpec{Name: "eip_type", Type: cty.String, Required: false},
 		"eip_bandwidth_size":           &hcldec.AttrSpec{Name: "eip_bandwidth_size", Type: cty.Number, Required: false},
-		"security_groups":              &hcldec.AttrSpec{Name: "security_groups", Type: cty.List(cty.String), Required: false},
-		"networks":                     &hcldec.AttrSpec{Name: "networks", Type: cty.List(cty.String), Required: false},
 		"vpc_id":                       &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},
 		"subnets":                      &hcldec.AttrSpec{Name: "subnets", Type: cty.List(cty.String), Required: false},
+		"security_groups":              &hcldec.AttrSpec{Name: "security_groups", Type: cty.List(cty.String), Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -90,14 +90,12 @@ type RunConfig struct {
 	EIPType string `mapstructure:"eip_type" required:"false"`
 	// The size of eip bandwidth.
 	EIPBandwidthSize int `mapstructure:"eip_bandwidth_size" required:"false"`
-	// A list of security groups by name to add to this instance.
-	SecurityGroups []string `mapstructure:"security_groups" required:"false"`
-	// A list of networks by UUID to attach to this instance.
-	Networks []string `mapstructure:"networks" required:"false"`
 	// A vpc id to attach to this instance.
 	VpcID string `mapstructure:"vpc_id" required:"false"`
 	// A list of subnets by UUID to attach to this instance.
 	Subnets []string `mapstructure:"subnets" required:"false"`
+	// A list of security groups by name to add to this instance.
+	SecurityGroups []string `mapstructure:"security_groups" required:"false"`
 	// User data to apply when launching the instance. Note that you need to be
 	// careful about escaping characters due to the templates being JSON. It is
 	// often more convenient to use user_data_file, instead. Packer will not

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -94,8 +94,6 @@ type RunConfig struct {
 	SecurityGroups []string `mapstructure:"security_groups" required:"false"`
 	// A list of networks by UUID to attach to this instance.
 	Networks []string `mapstructure:"networks" required:"false"`
-	// A list of ports by UUID to attach to this instance.
-	Ports []string `mapstructure:"ports" required:"false"`
 	// A vpc id to attach to this instance.
 	VpcID string `mapstructure:"vpc_id" required:"false"`
 	// A list of subnets by UUID to attach to this instance.

--- a/builder/ecs/step_run_source_server.go
+++ b/builder/ecs/step_run_source_server.go
@@ -16,10 +16,9 @@ import (
 
 type StepRunSourceServer struct {
 	Name             string
-	SecurityGroups   []string
-	Networks         []string
 	VpcID            string
 	Subnets          []string
+	SecurityGroups   []string
 	AvailabilityZone string
 	UserData         string
 	UserDataFile     string
@@ -173,21 +172,16 @@ func createServer(ui packer.Ui, state multistep.StateBag, client *golangsdk.Serv
 }
 
 func (s *StepRunSourceServer) getNetworks(config *Config) ([]servers.Network, error) {
-	networkIDs := make(map[string]bool)
+	if s.VpcID == "" {
+		return nil, nil
+	}
 
-	if (s.VpcID != "") && (len(s.Subnets) > 0) {
-		for _, subnetID := range s.Subnets {
-			networkIDs[subnetID] = true
+	networks := make([]servers.Network, len(s.Subnets))
+	for i, id := range s.Subnets {
+		networks[i] = servers.Network{
+			UUID: id,
 		}
 	}
 
-	for _, networkID := range s.Networks {
-		networkIDs[networkID] = true
-	}
-
-	networks := make([]servers.Network, 0, len(networkIDs))
-	for networkID := range networkIDs {
-		networks = append(networks, servers.Network{UUID: networkID})
-	}
 	return networks, nil
 }

--- a/builder/ecs/step_run_source_server.go
+++ b/builder/ecs/step_run_source_server.go
@@ -18,7 +18,6 @@ type StepRunSourceServer struct {
 	Name             string
 	SecurityGroups   []string
 	Networks         []string
-	Ports            []string
 	VpcID            string
 	Subnets          []string
 	AvailabilityZone string
@@ -186,12 +185,7 @@ func (s *StepRunSourceServer) getNetworks(config *Config) ([]servers.Network, er
 		networkIDs[networkID] = true
 	}
 
-	networks := make([]servers.Network, 0, len(networkIDs)+len(s.Ports))
-
-	for _, portID := range s.Ports {
-		networks = append(networks, servers.Network{Port: portID})
-	}
-
+	networks := make([]servers.Network, 0, len(networkIDs))
 	for networkID := range networkIDs {
 		networks = append(networks, servers.Network{UUID: networkID})
 	}

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -71,13 +71,11 @@
 
 - `eip_bandwidth_size` (int) - The size of eip bandwidth.
 
-- `security_groups` ([]string) - A list of security groups by name to add to this instance.
-
-- `networks` ([]string) - A list of networks by UUID to attach to this instance.
-
 - `vpc_id` (string) - A vpc id to attach to this instance.
 
 - `subnets` ([]string) - A list of subnets by UUID to attach to this instance.
+
+- `security_groups` ([]string) - A list of security groups by name to add to this instance.
 
 - `user_data` (string) - User data to apply when launching the instance. Note that you need to be
   careful about escaping characters due to the templates being JSON. It is

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -75,8 +75,6 @@
 
 - `networks` ([]string) - A list of networks by UUID to attach to this instance.
 
-- `ports` ([]string) - A list of ports by UUID to attach to this instance.
-
 - `vpc_id` (string) - A vpc id to attach to this instance.
 
 - `subnets` ([]string) - A list of subnets by UUID to attach to this instance.


### PR DESCRIPTION
delete `ports` and `networks` options, only keep **subents**

```
$ go test -v ./builder/ecs/...
=== RUN   TestArtifact_Impl
--- PASS: TestArtifact_Impl (0.00s)
=== RUN   TestArtifactId
--- PASS: TestArtifactId (0.00s)
=== RUN   TestArtifactString
--- PASS: TestArtifactString (0.00s)
=== RUN   TestBuilder_ImplementsBuilder
--- PASS: TestBuilder_ImplementsBuilder (0.00s)
=== RUN   TestBuilder_Prepare_BadType
--- PASS: TestBuilder_Prepare_BadType (0.00s)
=== RUN   TestImageConfigPrepare_Region
--- PASS: TestImageConfigPrepare_Region (0.00s)
=== RUN   TestRunConfigPrepare
--- PASS: TestRunConfigPrepare (0.00s)
=== RUN   TestRunConfigPrepare_InstanceType
--- PASS: TestRunConfigPrepare_InstanceType (0.00s)
=== RUN   TestRunConfigPrepare_SourceImage
--- PASS: TestRunConfigPrepare_SourceImage (0.00s)
=== RUN   TestRunConfigPrepare_SSHPort
--- PASS: TestRunConfigPrepare_SSHPort (0.00s)
=== RUN   TestRunConfigPrepare_BlockStorage
--- PASS: TestRunConfigPrepare_BlockStorage (0.00s)
=== RUN   TestBuildImageFilter
--- PASS: TestBuildImageFilter (0.00s)
=== RUN   TestBuildBadImageFilter
--- PASS: TestBuildBadImageFilter (0.00s)
=== RUN   TestImageFiltersEmpty
--- PASS: TestImageFiltersEmpty (0.00s)
=== RUN   TestBerToDer
2022/12/07 18:59:45 Couldn't parse SSH key, trying work around for [GH-2526].
2022/12/07 18:59:45 Executing: /usr/bin/openssl [rsa -in /tmp/packer-ber-privatekey-3826664413 -out /tmp/packer-der-privatekey-2480963165]
2022/12/07 18:59:45 ui: Successfully converted BER encoded SSH key to DER encoding.
--- PASS: TestBerToDer (0.02s)
PASS
ok      github.com/huaweicloud/packer-builder-huaweicloud-ecs/builder/ecs       0.036s
```