### PR TITLE
feat: depreacate ssh_interface option

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -67,11 +67,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
-	computeClient, err := b.config.computeV2Client()
-	if err != nil {
-		return nil, fmt.Errorf("Error initializing compute client: %s", err)
-	}
-
 	region := b.config.Region
 	imsClient, err := b.config.HcImsClient(region)
 	if err != nil {
@@ -133,12 +128,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			EIPBandwidthSize: b.config.EIPBandwidthSize,
 		},
 		&communicator.StepConnect{
-			Config: &b.config.RunConfig.Comm,
-			Host: CommHost(
-				b.config.RunConfig.Comm.SSHHost,
-				computeClient,
-				b.config.SSHInterface,
-				b.config.SSHIPVersion),
+			Config:    &b.config.RunConfig.Comm,
+			Host:      CommHost(b.config.RunConfig.Comm.SSHHost),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},
 		&commonsteps.StepProvision{},

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -79,17 +79,16 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	SSHInterface              *string           `mapstructure:"ssh_interface" required:"false" cty:"ssh_interface" hcl:"ssh_interface"`
-	SSHIPVersion              *string           `mapstructure:"ssh_ip_version" required:"false" cty:"ssh_ip_version" hcl:"ssh_ip_version"`
+	Flavor                    *string           `mapstructure:"flavor" required:"true" cty:"flavor" hcl:"flavor"`
 	SourceImage               *string           `mapstructure:"source_image" required:"false" cty:"source_image" hcl:"source_image"`
 	SourceImageName           *string           `mapstructure:"source_image_name" required:"false" cty:"source_image_name" hcl:"source_image_name"`
 	SourceImageFilters        *FlatImageFilter  `mapstructure:"source_image_filter" required:"false" cty:"source_image_filter" hcl:"source_image_filter"`
-	Flavor                    *string           `mapstructure:"flavor" required:"true" cty:"flavor" hcl:"flavor"`
 	AvailabilityZone          *string           `mapstructure:"availability_zone" required:"false" cty:"availability_zone" hcl:"availability_zone"`
 	FloatingIP                *string           `mapstructure:"floating_ip" required:"false" cty:"floating_ip" hcl:"floating_ip"`
 	ReuseIPs                  *bool             `mapstructure:"reuse_ips" required:"false" cty:"reuse_ips" hcl:"reuse_ips"`
 	EIPType                   *string           `mapstructure:"eip_type" required:"false" cty:"eip_type" hcl:"eip_type"`
 	EIPBandwidthSize          *int              `mapstructure:"eip_bandwidth_size" required:"false" cty:"eip_bandwidth_size" hcl:"eip_bandwidth_size"`
+	SSHIPVersion              *string           `mapstructure:"ssh_ip_version" required:"false" cty:"ssh_ip_version" hcl:"ssh_ip_version"`
 	VpcID                     *string           `mapstructure:"vpc_id" required:"false" cty:"vpc_id" hcl:"vpc_id"`
 	Subnets                   []string          `mapstructure:"subnets" required:"false" cty:"subnets" hcl:"subnets"`
 	SecurityGroups            []string          `mapstructure:"security_groups" required:"false" cty:"security_groups" hcl:"security_groups"`
@@ -184,17 +183,16 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
-		"ssh_interface":                &hcldec.AttrSpec{Name: "ssh_interface", Type: cty.String, Required: false},
-		"ssh_ip_version":               &hcldec.AttrSpec{Name: "ssh_ip_version", Type: cty.String, Required: false},
+		"flavor":                       &hcldec.AttrSpec{Name: "flavor", Type: cty.String, Required: false},
 		"source_image":                 &hcldec.AttrSpec{Name: "source_image", Type: cty.String, Required: false},
 		"source_image_name":            &hcldec.AttrSpec{Name: "source_image_name", Type: cty.String, Required: false},
 		"source_image_filter":          &hcldec.BlockSpec{TypeName: "source_image_filter", Nested: hcldec.ObjectSpec((*FlatImageFilter)(nil).HCL2Spec())},
-		"flavor":                       &hcldec.AttrSpec{Name: "flavor", Type: cty.String, Required: false},
 		"availability_zone":            &hcldec.AttrSpec{Name: "availability_zone", Type: cty.String, Required: false},
 		"floating_ip":                  &hcldec.AttrSpec{Name: "floating_ip", Type: cty.String, Required: false},
 		"reuse_ips":                    &hcldec.AttrSpec{Name: "reuse_ips", Type: cty.Bool, Required: false},
 		"eip_type":                     &hcldec.AttrSpec{Name: "eip_type", Type: cty.String, Required: false},
 		"eip_bandwidth_size":           &hcldec.AttrSpec{Name: "eip_bandwidth_size", Type: cty.Number, Required: false},
+		"ssh_ip_version":               &hcldec.AttrSpec{Name: "ssh_ip_version", Type: cty.String, Required: false},
 		"vpc_id":                       &hcldec.AttrSpec{Name: "vpc_id", Type: cty.String, Required: false},
 		"subnets":                      &hcldec.AttrSpec{Name: "subnets", Type: cty.List(cty.String), Required: false},
 		"security_groups":              &hcldec.AttrSpec{Name: "security_groups", Type: cty.List(cty.String), Required: false},

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -18,15 +18,8 @@ import (
 // and details on how to access that launched image.
 type RunConfig struct {
 	Comm communicator.Config `mapstructure:",squash"`
-	// The type of interface to connect via SSH, valid values are "public"
-	// and "private", and the default behavior is to connect via
-	// whichever is returned first from the HuaweiCloud API.
-	SSHInterface string `mapstructure:"ssh_interface" required:"false"`
-	// The IP version to use for SSH connections, valid values are `4` and `6`.
-	// Useful on dual stacked instances where the default behavior is to
-	// connect via whichever IP address is returned first from the HuaweiCloud
-	// API.
-	SSHIPVersion string `mapstructure:"ssh_ip_version" required:"false"`
+	// The ID or name for the desired flavor for the server to be created.
+	Flavor string `mapstructure:"flavor" required:"true"`
 	// The ID of the base image to use. This is the image that will
 	// be used to launch a new server and provision it. Unless you specify
 	// completely custom SSH settings, the source image must have cloud-init
@@ -72,8 +65,6 @@ type RunConfig struct {
 	// is provided alongside `source_image`, the `source_image` will override
 	// the filter. The filter will not be used in this case.
 	SourceImageFilters ImageFilter `mapstructure:"source_image_filter" required:"false"`
-	// The ID or name for the desired flavor for the server to be created.
-	Flavor string `mapstructure:"flavor" required:"true"`
 	// The availability zone to launch the server in.
 	// If omitted, a random availability zone in the region will be used.
 	AvailabilityZone string `mapstructure:"availability_zone" required:"false"`
@@ -90,6 +81,8 @@ type RunConfig struct {
 	EIPType string `mapstructure:"eip_type" required:"false"`
 	// The size of eip bandwidth.
 	EIPBandwidthSize int `mapstructure:"eip_bandwidth_size" required:"false"`
+	// The IP version to use for SSH connections, valid values are `4` and `6`.
+	SSHIPVersion string `mapstructure:"ssh_ip_version" required:"false"`
 	// A vpc id to attach to this instance.
 	VpcID string `mapstructure:"vpc_id" required:"false"`
 	// A list of subnets by UUID to attach to this instance.

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -1,14 +1,5 @@
 <!-- Code generated from the comments of the RunConfig struct in builder/ecs/run_config.go; DO NOT EDIT MANUALLY -->
 
-- `ssh_interface` (string) - The type of interface to connect via SSH, valid values are "public"
-  and "private", and the default behavior is to connect via
-  whichever is returned first from the HuaweiCloud API.
-
-- `ssh_ip_version` (string) - The IP version to use for SSH connections, valid values are `4` and `6`.
-  Useful on dual stacked instances where the default behavior is to
-  connect via whichever IP address is returned first from the HuaweiCloud
-  API.
-
 - `source_image` (string) - The ID of the base image to use. This is the image that will
   be used to launch a new server and provision it. Unless you specify
   completely custom SSH settings, the source image must have cloud-init
@@ -69,6 +60,8 @@
 - `eip_type` (string) - The type of eip. See the api doc to get the value.
 
 - `eip_bandwidth_size` (int) - The size of eip bandwidth.
+
+- `ssh_ip_version` (string) - The IP version to use for SSH connections, valid values are `4` and `6`.
 
 - `vpc_id` (string) - A vpc id to attach to this instance.
 


### PR DESCRIPTION
```
$ go test -v ./...
?       github.com/huaweicloud/packer-builder-huaweicloud-ecs   [no test files]
=== RUN   TestArtifact_Impl
--- PASS: TestArtifact_Impl (0.00s)
=== RUN   TestArtifactId
--- PASS: TestArtifactId (0.00s)
=== RUN   TestArtifactString
--- PASS: TestArtifactString (0.00s)
=== RUN   TestBuilder_ImplementsBuilder
--- PASS: TestBuilder_ImplementsBuilder (0.00s)
=== RUN   TestBuilder_Prepare_BadType
--- PASS: TestBuilder_Prepare_BadType (0.00s)
=== RUN   TestImageConfigPrepare_Region
--- PASS: TestImageConfigPrepare_Region (0.00s)
=== RUN   TestRunConfigPrepare
--- PASS: TestRunConfigPrepare (0.00s)
=== RUN   TestRunConfigPrepare_InstanceType
--- PASS: TestRunConfigPrepare_InstanceType (0.00s)
=== RUN   TestRunConfigPrepare_SourceImage
--- PASS: TestRunConfigPrepare_SourceImage (0.00s)
=== RUN   TestRunConfigPrepare_SSHPort
--- PASS: TestRunConfigPrepare_SSHPort (0.00s)
=== RUN   TestRunConfigPrepare_BlockStorage
--- PASS: TestRunConfigPrepare_BlockStorage (0.00s)
=== RUN   TestBuildImageFilter
--- PASS: TestBuildImageFilter (0.00s)
=== RUN   TestBuildBadImageFilter
--- PASS: TestBuildBadImageFilter (0.00s)
=== RUN   TestImageFiltersEmpty
--- PASS: TestImageFiltersEmpty (0.00s)
=== RUN   TestBerToDer
2022/12/12 15:42:16 Couldn't parse SSH key, trying work around for [GH-2526].
2022/12/12 15:42:16 Executing: /usr/bin/openssl [rsa -in /tmp/packer-ber-privatekey-2402765320 -out /tmp/packer-der-privatekey-4166078071]
2022/12/12 15:42:16 ui: Successfully converted BER encoded SSH key to DER encoding.
--- PASS: TestBerToDer (0.05s)
PASS
ok      github.com/huaweicloud/packer-builder-huaweicloud-ecs/builder/ecs       0.079s
```