### PR TITLE
get rid of post hook in plugin-check

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,13 +15,6 @@ builds:
   -
     id: plugin-check
     mod_timestamp: '{{ .CommitTimestamp }}'
-    hooks:
-      post:
-        # This will check plugin compatibility against latest version of Packer
-        - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
-            packer-plugins-check -load={{ .Name }}
-          dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:


### PR DESCRIPTION
fix the error when releasing:

```
go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest go: downloading github.com/hashicorp/packer v1.8.5 go: github.com/hashicorp/packer/cmd/packer-plugins-check@latest:
    module github.com/hashicorp/packer@latest found (v1.8.5), but does
    not contain package github.com/hashicorp/packer/cmd/packer-plugins-check
```