### PR TITLE
feat: support system-data image type

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -18,10 +18,11 @@ import (
 
 // The unique ID for this builder
 const (
-	BuilderId       string = "huawei.huaweicloud"
-	SystemImageType        = "system"
-	DataImageType          = "data-disk"
-	FullImageType          = "full-ecs"
+	BuilderId           string = "huawei.huaweicloud"
+	SystemImageType            = "system"      // system image only
+	DataImageType              = "data-disk"   // data disk images only
+	SystemDataImageType        = "system-data" // system image and data disk images
+	FullImageType              = "full-ecs"    // Full-ECS image, need vault_id
 )
 
 type Config struct {
@@ -192,7 +193,7 @@ func calculateAndValidateImageType(b *Builder) (string, error) {
 		}
 	} else {
 		// validate image_type if specified
-		var validTypes = []string{SystemImageType, DataImageType, FullImageType}
+		var validTypes = []string{SystemImageType, DataImageType, SystemDataImageType, FullImageType}
 		if !isStringInSlice(imageType, validTypes) {
 			return imageType, fmt.Errorf("expected 'image_type' to be one of %v, got %s", validTypes, imageType)
 		}

--- a/builder/ecs/image_config.go
+++ b/builder/ecs/image_config.go
@@ -15,7 +15,7 @@ type ImageConfig struct {
 	// The description of the packer image.
 	ImageDescription string `mapstructure:"image_description" required:"false"`
 	// The type of the packer image. Available values include:
-	// *system*, *data-disk*, *full-ecs*.
+	// *system*, *data-disk*, *system-data* and *full-ecs*.
 	ImageType string `mapstructure:"image_type" required:"false"`
 	// The tags of the packer image in key/value format.
 	ImageTags map[string]string `mapstructure:"image_tags" required:"false"`

--- a/docs-partials/builder/ecs/ImageConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/ImageConfig-not-required.mdx
@@ -3,7 +3,7 @@
 - `image_description` (string) - The description of the packer image.
 
 - `image_type` (string) - The type of the packer image. Available values include:
-  *system*, *data-disk*, *full-ecs*.
+  *system*, *data-disk*, *system-data* and *full-ecs*.
 
 - `image_tags` (map[string]string) - The tags of the packer image in key/value format.
 


### PR DESCRIPTION
add a new value of image_type: **system-data** to make system  image and data disk image in one time.