### PR TITLE
feat: support spot price mode when creating ECS

### DIFF
--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -101,6 +101,8 @@ type FlatConfig struct {
 	InstanceName              *string           `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	InstanceMetadata          map[string]string `mapstructure:"instance_metadata" required:"false" cty:"instance_metadata" hcl:"instance_metadata"`
 	ConfigDrive               *bool             `mapstructure:"config_drive" required:"false" cty:"config_drive" hcl:"config_drive"`
+	SpotPricing               *bool             `mapstructure:"spot_pricing" required:"false" cty:"spot_pricing" hcl:"spot_pricing"`
+	SpotMaximumPrice          *string           `mapstructure:"spot_maximum_price" required:"false" cty:"spot_maximum_price" hcl:"spot_maximum_price"`
 	VolumeType                *string           `mapstructure:"volume_type" required:"false" cty:"volume_type" hcl:"volume_type"`
 	VolumeSize                *int              `mapstructure:"volume_size" required:"false" cty:"volume_size" hcl:"volume_size"`
 	DataVolumes               []FlatDataVolume  `mapstructure:"data_disks" required:"false" cty:"data_disks" hcl:"data_disks"`
@@ -210,6 +212,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"instance_metadata":            &hcldec.AttrSpec{Name: "instance_metadata", Type: cty.Map(cty.String), Required: false},
 		"config_drive":                 &hcldec.AttrSpec{Name: "config_drive", Type: cty.Bool, Required: false},
+		"spot_pricing":                 &hcldec.AttrSpec{Name: "spot_pricing", Type: cty.Bool, Required: false},
+		"spot_maximum_price":           &hcldec.AttrSpec{Name: "spot_maximum_price", Type: cty.String, Required: false},
 		"volume_type":                  &hcldec.AttrSpec{Name: "volume_type", Type: cty.String, Required: false},
 		"volume_size":                  &hcldec.AttrSpec{Name: "volume_size", Type: cty.Number, Required: false},
 		"data_disks":                   &hcldec.BlockListSpec{TypeName: "data_disks", Nested: hcldec.ObjectSpec((*FlatDataVolume)(nil).HCL2Spec())},

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -110,6 +110,13 @@ type RunConfig struct {
 	InstanceMetadata map[string]string `mapstructure:"instance_metadata" required:"false"`
 	// Whether or not nova should use ConfigDrive for cloud-init metadata.
 	ConfigDrive bool `mapstructure:"config_drive" required:"false"`
+	// If set to true, the ECS will be billed in spot price mode.
+	// This mode is more cost-effective than pay-per-use, and the spot price will be adjusted based on supply-and-demand changes.
+	SpotPricing bool `mapstructure:"spot_pricing" required:"false"`
+	// The highest price you are willing to pay for an ECS. This price is not lower than the current market price and
+	// not higher than the pay-per-use price. When the market price is higher than your quoting or the inventory is insufficient,
+	// the spot ECS will be terminated.
+	SpotMaximumPrice string `mapstructure:"spot_maximum_price" required:"false"`
 	// The system disk type of the instance. Defaults to `SSD`.
 	// For details about disk types, see
 	// [Disk Types and Disk Performance](https://support.huaweicloud.com/en-us/productdesc-evs/en-us_topic_0014580744.html).

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -89,6 +89,13 @@
 
 - `config_drive` (bool) - Whether or not nova should use ConfigDrive for cloud-init metadata.
 
+- `spot_pricing` (bool) - If set to true, the ECS will be billed in spot price mode.
+  This mode is more cost-effective than pay-per-use, and the spot price will be adjusted based on supply-and-demand changes.
+
+- `spot_maximum_price` (string) - The highest price you are willing to pay for an ECS. This price is not lower than the current market price and
+  not higher than the pay-per-use price. When the market price is higher than your quoting or the inventory is insufficient,
+  the spot ECS will be terminated.
+
 - `volume_type` (string) - The system disk type of the instance. Defaults to `SSD`.
   For details about disk types, see
   [Disk Types and Disk Performance](https://support.huaweicloud.com/en-us/productdesc-evs/en-us_topic_0014580744.html).


### PR DESCRIPTION
fixes #79 

```
$ go test -v ./...
?       github.com/huaweicloud/packer-builder-huaweicloud-ecs   [no test files]
=== RUN   TestArtifact_Impl
--- PASS: TestArtifact_Impl (0.00s)
=== RUN   TestArtifactId
--- PASS: TestArtifactId (0.00s)
=== RUN   TestArtifactString
--- PASS: TestArtifactString (0.00s)
=== RUN   TestBuilder_ImplementsBuilder
--- PASS: TestBuilder_ImplementsBuilder (0.00s)
=== RUN   TestBuilder_Prepare_BadType
--- PASS: TestBuilder_Prepare_BadType (0.00s)
=== RUN   TestImageConfigPrepare_Region
--- PASS: TestImageConfigPrepare_Region (0.00s)
=== RUN   TestRunConfigPrepare
--- PASS: TestRunConfigPrepare (0.00s)
=== RUN   TestRunConfigPrepare_InstanceType
--- PASS: TestRunConfigPrepare_InstanceType (0.00s)
=== RUN   TestRunConfigPrepare_SourceImage
--- PASS: TestRunConfigPrepare_SourceImage (0.00s)
=== RUN   TestRunConfigPrepare_SSHPort
--- PASS: TestRunConfigPrepare_SSHPort (0.00s)
=== RUN   TestRunConfigPrepare_BlockStorage
--- PASS: TestRunConfigPrepare_BlockStorage (0.00s)
=== RUN   TestBuildImageFilter
--- PASS: TestBuildImageFilter (0.00s)
=== RUN   TestBuildBadImageFilter
--- PASS: TestBuildBadImageFilter (0.00s)
=== RUN   TestImageFiltersEmpty
--- PASS: TestImageFiltersEmpty (0.00s)
=== RUN   TestBerToDer
2023/07/04 20:51:14 Couldn't parse SSH key, trying work around for [GH-2526].
2023/07/04 20:51:14 Executing: /usr/bin/openssl [rsa -in /tmp/packer-ber-privatekey-2610527326 -out /tmp/packer-der-privatekey-3994203908]
2023/07/04 20:51:14 ui: Successfully converted BER encoded SSH key to DER encoding.
--- PASS: TestBerToDer (0.07s)
PASS
ok      github.com/huaweicloud/packer-builder-huaweicloud-ecs/builder/ecs       0.093s
```