### PR TITLE
chore: remove config_drive param

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -133,7 +133,6 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			RootVolumeSize:   b.config.VolumeSize,
 			UserData:         b.config.UserData,
 			UserDataFile:     b.config.UserDataFile,
-			ConfigDrive:      b.config.ConfigDrive,
 			InstanceMetadata: b.config.InstanceMetadata,
 		},
 		&StepAttachVolume{

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -100,7 +100,6 @@ type FlatConfig struct {
 	UserDataFile              *string           `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	InstanceName              *string           `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	InstanceMetadata          map[string]string `mapstructure:"instance_metadata" required:"false" cty:"instance_metadata" hcl:"instance_metadata"`
-	ConfigDrive               *bool             `mapstructure:"config_drive" required:"false" cty:"config_drive" hcl:"config_drive"`
 	SpotPricing               *bool             `mapstructure:"spot_pricing" required:"false" cty:"spot_pricing" hcl:"spot_pricing"`
 	SpotMaximumPrice          *string           `mapstructure:"spot_maximum_price" required:"false" cty:"spot_maximum_price" hcl:"spot_maximum_price"`
 	VolumeType                *string           `mapstructure:"volume_type" required:"false" cty:"volume_type" hcl:"volume_type"`
@@ -211,7 +210,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"instance_metadata":            &hcldec.AttrSpec{Name: "instance_metadata", Type: cty.Map(cty.String), Required: false},
-		"config_drive":                 &hcldec.AttrSpec{Name: "config_drive", Type: cty.Bool, Required: false},
 		"spot_pricing":                 &hcldec.AttrSpec{Name: "spot_pricing", Type: cty.Bool, Required: false},
 		"spot_maximum_price":           &hcldec.AttrSpec{Name: "spot_maximum_price", Type: cty.String, Required: false},
 		"volume_type":                  &hcldec.AttrSpec{Name: "volume_type", Type: cty.String, Required: false},

--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -108,8 +108,6 @@ type RunConfig struct {
 	// called server properties in some documentation. The strings have a max
 	// size of 255 bytes each.
 	InstanceMetadata map[string]string `mapstructure:"instance_metadata" required:"false"`
-	// Whether or not nova should use ConfigDrive for cloud-init metadata.
-	ConfigDrive bool `mapstructure:"config_drive" required:"false"`
 	// If set to true, the ECS will be billed in spot price mode.
 	// This mode is more cost-effective than pay-per-use, and the spot price will be adjusted based on supply-and-demand changes.
 	SpotPricing bool `mapstructure:"spot_pricing" required:"false"`

--- a/builder/ecs/step_run_source_server.go
+++ b/builder/ecs/step_run_source_server.go
@@ -24,7 +24,6 @@ type StepRunSourceServer struct {
 	RootVolumeSize   int
 	UserData         string
 	UserDataFile     string
-	ConfigDrive      bool
 	InstanceMetadata map[string]string
 	serverID         string
 }

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -87,8 +87,6 @@
   called server properties in some documentation. The strings have a max
   size of 255 bytes each.
 
-- `config_drive` (bool) - Whether or not nova should use ConfigDrive for cloud-init metadata.
-
 - `spot_pricing` (bool) - If set to true, the ECS will be billed in spot price mode.
   This mode is more cost-effective than pay-per-use, and the spot price will be adjusted based on supply-and-demand changes.
 


### PR DESCRIPTION
`config_drive` is no longer used, so let's remove it.