### PR TITLE
Support server_tags for ECS instance

### DIFF
--- a/builder/ecs/builder.go
+++ b/builder/ecs/builder.go
@@ -135,6 +135,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			UserData:         b.config.UserData,
 			UserDataFile:     b.config.UserDataFile,
 			InstanceMetadata: b.config.InstanceMetadata,
+			ServerTags:       b.config.ServerTags,
 		},
 		&StepAttachVolume{
 			PrefixName: b.config.InstanceName,

--- a/builder/ecs/builder.hcl2spec.go
+++ b/builder/ecs/builder.hcl2spec.go
@@ -100,6 +100,7 @@ type FlatConfig struct {
 	UserDataFile              *string           `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	InstanceName              *string           `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	InstanceMetadata          map[string]string `mapstructure:"instance_metadata" required:"false" cty:"instance_metadata" hcl:"instance_metadata"`
+	ServerTags                map[string]string `mapstructure:"server_tags" required:"false" cty:"server_tags" hcl:"server_tags"`
 	SpotPricing               *bool             `mapstructure:"spot_pricing" required:"false" cty:"spot_pricing" hcl:"spot_pricing"`
 	SpotMaximumPrice          *string           `mapstructure:"spot_maximum_price" required:"false" cty:"spot_maximum_price" hcl:"spot_maximum_price"`
 	VolumeType                *string           `mapstructure:"volume_type" required:"false" cty:"volume_type" hcl:"volume_type"`
@@ -211,6 +212,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"instance_metadata":            &hcldec.AttrSpec{Name: "instance_metadata", Type: cty.Map(cty.String), Required: false},
+		"server_tags":                  &hcldec.AttrSpec{Name: "server_tags", Type: cty.Map(cty.String), Required: false},
 		"spot_pricing":                 &hcldec.AttrSpec{Name: "spot_pricing", Type: cty.Bool, Required: false},
 		"spot_maximum_price":           &hcldec.AttrSpec{Name: "spot_maximum_price", Type: cty.String, Required: false},
 		"volume_type":                  &hcldec.AttrSpec{Name: "volume_type", Type: cty.String, Required: false},

--- a/builder/ecs/step_run_source_server.go
+++ b/builder/ecs/step_run_source_server.go
@@ -26,6 +26,7 @@ type StepRunSourceServer struct {
 	UserData         string
 	UserDataFile     string
 	InstanceMetadata map[string]string
+	ServerTags       map[string]string
 	serverID         string
 }
 
@@ -68,6 +69,11 @@ func (s *StepRunSourceServer) Run(ctx context.Context, state multistep.StateBag)
 	availabilityZone := state.Get("availability_zone").(string)
 	ui.Say(fmt.Sprintf("Launching server in AZ %s...", availabilityZone))
 
+	serverTags := make([]model.PostPaidServerTag, 0, len(s.ServerTags))
+	for key, value := range s.ServerTags {
+		serverTags = append(serverTags, model.PostPaidServerTag{Key: key, Value: value})
+	}
+
 	keyName := config.Comm.SSHKeyPairName
 	serverbody := &model.PostPaidServer{
 		Name:             s.Name,
@@ -82,6 +88,7 @@ func (s *StepRunSourceServer) Run(ctx context.Context, state multistep.StateBag)
 		Publicip:         publicIP,
 		UserData:         &userData,
 		Metadata:         s.InstanceMetadata,
+		ServerTags:       &serverTags,
 	}
 
 	var chargingMode int32 = 0

--- a/docs-partials/builder/ecs/RunConfig-not-required.mdx
+++ b/docs-partials/builder/ecs/RunConfig-not-required.mdx
@@ -87,6 +87,10 @@
   called server properties in some documentation. The strings have a max
   size of 255 bytes each.
 
+- `server_tags` (map[string]string) - Tags (key-value pairs) that are applied to the server instance created by Packer. Also
+  tags are applied to the system disk of the instance. Key is no longer than 36 characters,
+  value is no longer than 43 characters. Symbols "=*<>,|/\\" are not allowed. Key can't be empty.
+
 - `spot_pricing` (bool) - If set to true, the ECS will be billed in spot price mode.
   This mode is more cost-effective than pay-per-use, and the spot price will be adjusted based on supply-and-demand changes.
 


### PR DESCRIPTION
Allows to use server tags for a builder instance. Useful for accounting purpose.