### PR TITLE
feat: user data support both plaint text or encoded with base64 format

### DIFF
--- a/builder/ecs/run_config.go
+++ b/builder/ecs/run_config.go
@@ -309,6 +309,14 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.sourceImageOpts = listOpts
 	}
 
+	// check user data file whether exists
+	if c.UserDataFile != "" {
+		_, fileErr := os.Stat(c.UserDataFile)
+		if fileErr != nil {
+			errs = append(errs, fmt.Errorf("the user data file %s is not exist", c.UserDataFile))
+		}
+	}
+
 	return errs
 }
 


### PR DESCRIPTION
1. try to encode the user_data if it is not encoded with base64;
2. add pre-check for `user_data_file`;