### PR TITLE
feat: post processor support quick import

### DIFF
--- a/docs-partials/post-processor/huaweicloud-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/huaweicloud-import/Config-not-required.mdx
@@ -14,8 +14,12 @@
 - `enterprise_project_id` (string) - The ID of Enterprise Project in which to create the image.
   If omitted, the HW_ENTERPRISE_PROJECT_ID environment variable is used.
 
-- `skip_clean` (bool) - Whether we should skip removing the RAW, VHD, VMDK, or qcow2 file uploaded to
-  OBS after the import process has completed. Possible values are: `true` to
+- `quick_import` (bool) - Whether to use the quick import method to import the image. (Default: `false`).
+  Currently, only `raw` and `zvhd2` image files are supported, and the size of an image file cannot exceed 1 TB.
+  You are advised to import image files that are smaller than 128 GB with the common method.
+
+- `skip_clean` (bool) - Whether we should skip removing the source image file uploaded to OBS
+  after the import process has completed. Possible values are: `true` to
   leave it in the OBS bucket, `false` to remove it. (Default: `false`).
 
 - `wait_image_ready_timeout` (string) - Timeout of creating the image. The timeout string is a possibly signed sequence of

--- a/docs-partials/post-processor/huaweicloud-import/Config-required.mdx
+++ b/docs-partials/post-processor/huaweicloud-import/Config-required.mdx
@@ -11,6 +11,6 @@
 
 - `min_disk` (int) - The minimum size (GB) of the system disk, the value ranges from 1 to 1024 and must be greater than the size of the image file.
 
-- `format` (string) - The format of the import image , Possible values are: `raw`, `vhd`, `vmdk`, or `qcow2`.
+- `format` (string) - The format of the import image , Possible values are: `raw`, `zvhd2`, `vmdk` or `qcow2`.
 
 <!-- End of code generated from the comments of the Config struct in post-processor/huaweicloud-import/post-processor.go; -->

--- a/post-processor/huaweicloud-import/obs-util_test.go
+++ b/post-processor/huaweicloud-import/obs-util_test.go
@@ -1,0 +1,27 @@
+package huaweicloudimport
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-obs/obs"
+)
+
+func TestUploadFileToObject(t *testing.T) {
+	region := os.Getenv("HW_REGION_NAME")
+	ak := os.Getenv("HW_ACCESS_KEY")
+	sk := os.Getenv("HW_SECRET_KEY")
+	obsEndpoint := fmt.Sprintf("https://obs.%s.myhuaweicloud.com", region)
+	envProxyConfigure := obs.WithProxyFromEnv(true)
+
+	client, err := obs.New(ak, sk, obsEndpoint, obs.WithSignature("OBS"), envProxyConfigure)
+	if err != nil {
+		t.Fatalf("failed to create OBS client: %s", err)
+	}
+
+	err = uploadFileToObject(client, "image-test", "packer-import-test.raw", "./source-image-test.raw")
+	if err != nil {
+		t.Fatalf("failed to upload file: %s", err)
+	}
+}

--- a/post-processor/huaweicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/huaweicloud-import/post-processor.hcl2spec.go
@@ -38,6 +38,7 @@ type FlatConfig struct {
 	ImageTags             map[string]string `mapstructure:"image_tags" required:"false" cty:"image_tags" hcl:"image_tags"`
 	ImageArchitecture     *string           `mapstructure:"image_architecture" required:"false" cty:"image_architecture" hcl:"image_architecture"`
 	EnterpriseProjectId   *string           `mapstructure:"enterprise_project_id" required:"false" cty:"enterprise_project_id" hcl:"enterprise_project_id"`
+	QuickImport           *bool             `mapstructure:"quick_import" required:"false" cty:"quick_import" hcl:"quick_import"`
 	SkipClean             *bool             `mapstructure:"skip_clean" required:"false" cty:"skip_clean" hcl:"skip_clean"`
 	WaitImageReadyTimeout *string           `mapstructure:"wait_image_ready_timeout" required:"false" cty:"wait_image_ready_timeout" hcl:"wait_image_ready_timeout"`
 }
@@ -82,6 +83,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_tags":                 &hcldec.AttrSpec{Name: "image_tags", Type: cty.Map(cty.String), Required: false},
 		"image_architecture":         &hcldec.AttrSpec{Name: "image_architecture", Type: cty.String, Required: false},
 		"enterprise_project_id":      &hcldec.AttrSpec{Name: "enterprise_project_id", Type: cty.String, Required: false},
+		"quick_import":               &hcldec.AttrSpec{Name: "quick_import", Type: cty.Bool, Required: false},
 		"skip_clean":                 &hcldec.AttrSpec{Name: "skip_clean", Type: cty.Bool, Required: false},
 		"wait_image_ready_timeout":   &hcldec.AttrSpec{Name: "wait_image_ready_timeout", Type: cty.String, Required: false},
 	}


### PR DESCRIPTION

```bash
# packer build centos.json
qemu: output will be in this color.

==> qemu: Retrieving ISO
==> qemu: Trying http://mirrors.aliyun.com/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-2207-02.iso
==> qemu: Trying http://mirrors.aliyun.com/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-2207-02.iso?checksum=md5%3A3e39d08511a014c16730650051a0dcca
==> qemu: http://mirrors.aliyun.com/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-2207-02.iso?checksum=md5%3A3e39d08511a014c16730650051a0dcca => /root/.cache/packer/8ec06c32259b22f935a8eaea65f1341e4731bc4e.iso
==> qemu: Starting HTTP server on port 8049
    qemu: No communicator is set; skipping port forwarding setup.
==> qemu: Looking for available port between 5900 and 6000 on 127.0.0.1
==> qemu: Starting VM, booting from CD-ROM
==> qemu: Waiting 10s for boot...
==> qemu: Connecting to VM via VNC (127.0.0.1:5972)
==> qemu: Typing the boot commands over VNC...
    qemu: No communicator is configured -- skipping StepWaitGuestAddress
==> qemu: Waiting for shutdown...
==> qemu: Running post-processor: huaweicloud-import
    qemu (huaweicloud-import): Rendered obs_object_name as packer-import-1711694677.raw
    qemu (huaweicloud-import): Looking for image in artifact
==> qemu (huaweicloud-import): Waiting for uploading image file packer-centos-7-x86_64-qemu/centos-7-x86_64.raw to OBS image-sck/packer-import-1711694677.raw ...
==> qemu (huaweicloud-import): Image file packer-centos-7-x86_64-qemu/centos-7-x86_64.raw has been uploaded to OBS image-sck/packer-import-1711694677.raw
==> qemu (huaweicloud-import): Waiting for importing image from OBS image-sck/packer-import-1711694677.raw ...
==> qemu (huaweicloud-import): Importing the image ID as 45791b3f-1813-4a36-a676-8dda82a988d4 in region cn-north-4 completed
    qemu (huaweicloud-import): Deleting import source OBS object packer-import-1711694677.raw/packer-import-1711694677.raw
Build 'qemu' finished after 17 minutes 3 seconds.

```