### PR TITLE
fix: resolve security group ID pointer reuse causing data corruption

### DIFF
--- a/builder/ecs/step_run_source_server.go
+++ b/builder/ecs/step_run_source_server.go
@@ -346,8 +346,9 @@ func (s *StepRunSourceServer) buildSecurityGroups() []model.PostPaidServerSecuri
 			continue
 		}
 
+		currentID := id
 		secGroups = append(secGroups, model.PostPaidServerSecurityGroup{
-			Id: &id,
+			Id: &currentID,
 		})
 	}
 


### PR DESCRIPTION
## Change Description

In the `buildSecurityGroups` method, the loop variable `id` is reused across iterations when iterating through the security group ID list `rawGroups`. By taking the pointer `&id`, all `PostPaidServerSecurityGroup` instances' `Id` fields end up pointing to the **same memory address**, causing all security group IDs to be overwritten with the value from the last iteration.